### PR TITLE
Add local_extra.txt requirements file

### DIFF
--- a/compose/local/django/start
+++ b/compose/local/django/start
@@ -4,6 +4,6 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-
+pip install --root-user-action=ignore -r requirements/local_extra.txt
 python manage.py migrate
 exec python manage.py runserver_plus 0.0.0.0:8000

--- a/requirements/local_extra.txt
+++ b/requirements/local_extra.txt
@@ -1,0 +1,3 @@
+# Installed by local deployment on each startup
+# Useful if developing a processor/executor that requires extra dependencies
+# -----------------------------------------------------------


### PR DESCRIPTION
Add an additional pip requirements file which is installed on each launch of local Spade.

The reason for this addition is that, outside of updating local.txt and rebuilding the image or opening a shell in the django container to run `pip install`, there is no way to install extra dependencies to a local Spade deployment. This can make developing processors which use extra dependencies difficult. With this addition, a developer can just add the extra dependencies to this file and restart the docker compose to install them, or recreate the container to clear it.