### PR TITLE
Update install guide

### DIFF
--- a/docs/getting-started/run-locally.md
+++ b/docs/getting-started/run-locally.md
@@ -25,8 +25,28 @@ This will bring up the Spade backend server on your local machine. You can acces
 
 To run the frontend locally:
 
-1. Clone the Spade UI repo https://github.com/crugroup/spadeui)
-2. Install the required dependencies by running `yarn install`
-3. Start the server by running `yarn start`
+1. Clone the Spade UI repo (https://github.com/crugroup/spadeui)
+2. This project requires [yarn](https://yarnpkg.com/).
+    You can install it globally on your machine.
 
-This will bring up the Spade frontend server on your local machine. You can access the server by visiting `http://localhost:5173` in your browser.
+**macOS (with Homebrew)**
+```bash
+brew install yarn
+```
+**Windows (with Chocolatey)**
+```powershell
+choco install yarn
+```
+**Linux (Debian/Ubuntu)**
+```bash
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+sudo apt update && sudo apt install yarn
+```
+
+3. Install the required dependencies by running `yarn install`
+4. Start the server by running:
+    - `yarn dev`: for local development
+    - `yarn build && yarn start`: for production build + preview
+
+This will bring up the Spade frontend server on your local machine. You can access the server by visiting `http://localhost:5173` in your browser for local development or `http://localhost:4173` in your browser for production build and preview.

--- a/docs/getting-started/run-locally.md
+++ b/docs/getting-started/run-locally.md
@@ -49,7 +49,7 @@ curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 sudo apt update && sudo apt install yarn
 ```
-⚠️ For installing yarn on Windows and Linux have not been tested, please run those commands with caution.
+⚠️ Installing yarn on Windows and Linux has not been tested; please run those commands with caution.
 
 3. Install the required dependencies by running `yarn install`
 4. Start the server by running:

--- a/docs/getting-started/run-locally.md
+++ b/docs/getting-started/run-locally.md
@@ -29,10 +29,16 @@ To run the frontend locally:
 2. This project requires [yarn](https://yarnpkg.com/).
     You can install it globally on your machine.
 
+Here is the recommended method for installing yarn with corepack for MacOS:
+
 **macOS (with Homebrew)**
 ```bash
-brew install yarn
+brew install node
+npm install --global yarn
+corepack enable
+corepack prepare yarn@4.6.0 --activate
 ```
+
 **Windows (with Chocolatey)**
 ```powershell
 choco install yarn
@@ -43,6 +49,7 @@ curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 sudo apt update && sudo apt install yarn
 ```
+⚠️ For installing yarn on Windows and Linux have not been tested, please run those commands with caution.
 
 3. Install the required dependencies by running `yarn install`
 4. Start the server by running:


### PR DESCRIPTION
This pull request updates the frontend setup instructions in the documentation to provide clearer guidance on installing dependencies and starting the server, including platform-specific steps for installing `yarn`.

Documentation improvements:

* Added platform-specific installation instructions for `yarn`
* Clarified the steps to start the frontend server, distinguishing between development (`yarn dev`) and production (`yarn build && yarn start`) modes, and updated the URLs for accessing each mode
* Specified the requirement to install `yarn` and recommended using corepack for managing `yarn` versions