### PR TITLE
Fix latest run serialization for provider results

### DIFF
--- a/spadeapp/processes/api.py
+++ b/spadeapp/processes/api.py
@@ -60,7 +60,7 @@ class ProcessViewSet(AutoPermissionViewSetMixin, viewsets.ModelViewSet):
         payload = [
             {
                 "process_id": process.id,
-                "latest_run": serializers.ProcessRunSerializer(latest_runs_by_process_id.get(process.id)).data
+                "latest_run": latest_runs_by_process_id.get(process.id)
                 if process.id in latest_runs_by_process_id
                 else None,
             }

--- a/spadeapp/processes/service.py
+++ b/spadeapp/processes/service.py
@@ -56,6 +56,8 @@ class ProcessService:
         if cache_key and cache_timeout > 0:
             cached_payload = cache.get(cache_key)
             if cached_payload is not None:
+                user_ids = {run["user_id"] for run in cached_payload.values() if run.get("user_id")}
+                users_by_id = User.objects.in_bulk(user_ids)
                 return {
                     int(process_id): ProcessRun(
                         process=next(process for process in processes if process.id == int(process_id)),
@@ -64,7 +66,7 @@ class ProcessService:
                         output=run["output"],
                         error_message=run["error_message"],
                         created_at=run["created_at"],
-                        user_id=run.get("user_id"),
+                        user=users_by_id.get(run.get("user_id")),
                     )
                     for process_id, run in cached_payload.items()
                 }
@@ -246,6 +248,8 @@ class ProcessService:
             if cache_key and cache_timeout > 0:
                 cache.set(cache_key, cached_runs, cache_timeout)
 
+        user_ids = {run["user_id"] for run in cached_runs if run.get("user_id")}
+        users_by_id = User.objects.in_bulk(user_ids)
         return [
             ProcessRun(
                 process=process,
@@ -254,7 +258,7 @@ class ProcessService:
                 output=run["output"],
                 error_message=run["error_message"],
                 created_at=run["created_at"],
-                user_id=run.get("user_id"),
+                user=users_by_id.get(run.get("user_id")),
             )
             for run in cached_runs
         ]


### PR DESCRIPTION
This pull request updates how user information is handled for process runs, ensuring that the `user` field is populated with the actual `User` object instead of just the user ID. This improves the consistency and usability of the data returned by the API and service methods, especially when using cached results