### PR TITLE
fix: normalize SDK status enum, invalidate cache on run, fix HTTP code

### DIFF
--- a/spadeapp/processes/api.py
+++ b/spadeapp/processes/api.py
@@ -74,7 +74,7 @@ class ProcessViewSet(AutoPermissionViewSetMixin, viewsets.ModelViewSet):
         request=serializers.ProcessRunParamsSerializer,
         responses={
             200: serializers.ProcessRunSerializer,
-            500: serializers.ProcessRunSerializer,
+            400: serializers.ProcessRunSerializer,
         },
     )
     @decorators.action(detail=True, methods=["post"], permission_classes=[PostRequiresViewPermission])

--- a/spadeapp/processes/api.py
+++ b/spadeapp/processes/api.py
@@ -85,7 +85,9 @@ class ProcessViewSet(AutoPermissionViewSetMixin, viewsets.ModelViewSet):
         )
 
         return Response(
-            status=status.HTTP_200_OK if run.status != "failed" else status.HTTP_400_BAD_REQUEST,
+            status=status.HTTP_200_OK
+            if run.status not in ("failed", models.ProcessRun.Statuses.ERROR)
+            else status.HTTP_400_BAD_REQUEST,
             data=serializer.data,
         )
 

--- a/spadeapp/processes/service.py
+++ b/spadeapp/processes/service.py
@@ -39,12 +39,28 @@ class ProcessService:
         )
 
     @staticmethod
+    def _bump_user_cache_version(user_id) -> None:
+        """Increment the per-user cache version counter.
+
+        This effectively invalidates *all* ``latest_runs`` cache entries for the
+        given user regardless of which process-ID combination was cached, since
+        every new version produces a different cache key.
+        """
+        version_key = f"latest-runs-version:{user_id}"
+        try:
+            cache.incr(version_key)
+        except ValueError:
+            # Key does not exist yet; initialise it.
+            cache.set(version_key, 1, timeout=86400 * 7)
+
+    @staticmethod
     def _get_latest_runs_cache_key(process_ids: list[int], request) -> str | None:
         if not process_ids:
             return None
 
         user_id = getattr(getattr(request, "user", None), "id", "anon")
-        return ":".join(["latest-process-runs", str(user_id), ",".join(map(str, sorted(process_ids)))])
+        version = cache.get(f"latest-runs-version:{user_id}", 0)
+        return ":".join(["latest-process-runs", str(user_id), str(version), ",".join(map(str, sorted(process_ids)))])
 
     @staticmethod
     def get_latest_runs_for_processes(processes: list[Process], request) -> dict[int, ProcessRun]:
@@ -190,16 +206,17 @@ class ProcessService:
             else:
                 run.status = sdk_status
             run.save()
-            # Invalidate the latest_runs cache so the frontend sees the new run immediately
-            cache_key = ProcessService._get_latest_runs_cache_key([process.id], None)
-            if cache_key:
-                cache.delete(cache_key)
+            # Invalidate all latest_runs caches for this user so the frontend
+            # sees the new run immediately, regardless of which process-ID
+            # combination was cached.
+            ProcessService._bump_user_cache_version(user.id)
         except Exception as e:
             logger.exception(f"Error running process {process}")
             run.status = ProcessRun.Statuses.ERROR
             run.result = ProcessRun.Results.FAILED
             run.error_message = str(e)
             run.save()
+            ProcessService._bump_user_cache_version(user.id)
 
         return run
 

--- a/spadeapp/processes/service.py
+++ b/spadeapp/processes/service.py
@@ -49,9 +49,11 @@ class ProcessService:
         version_key = f"latest-runs-version:{user_id}"
         try:
             cache.incr(version_key)
-        except ValueError:
-            # Key does not exist yet; initialise it.
-            cache.set(version_key, 1, timeout=86400 * 7)
+        except ValueError, NotImplementedError:
+            # ValueError: key does not exist yet.
+            # NotImplementedError: backend doesn't support atomic incr; fall back.
+            current = cache.get(version_key, 0) or 0
+            cache.set(version_key, int(current) + 1, timeout=86400 * 7)
 
     @staticmethod
     def _get_latest_runs_cache_key(process_ids: list[int], request) -> str | None:
@@ -174,6 +176,7 @@ class ProcessService:
             run.error_message = "Failed to parse user params as JSON"
             run.status = ProcessRun.Statuses.ERROR
             run.save()
+            ProcessService._bump_user_cache_version(user.id)
             return run
 
         try:

--- a/spadeapp/processes/service.py
+++ b/spadeapp/processes/service.py
@@ -183,8 +183,17 @@ class ProcessService:
             run.result = result.result.value if result.result else None
             run.output = result.output
             run.error_message = result.error_message
-            run.status = result.status.value
+            # Normalize SDK status: the SDK uses "failed" but the model uses "error"
+            sdk_status = result.status.value
+            if sdk_status == "failed":
+                run.status = ProcessRun.Statuses.ERROR
+            else:
+                run.status = sdk_status
             run.save()
+            # Invalidate the latest_runs cache so the frontend sees the new run immediately
+            cache_key = ProcessService._get_latest_runs_cache_key([process.id], None)
+            if cache_key:
+                cache.delete(cache_key)
         except Exception as e:
             logger.exception(f"Error running process {process}")
             run.status = ProcessRun.Statuses.ERROR


### PR DESCRIPTION
This pull request introduces improvements to cache invalidation for latest process runs, normalizes error status handling, and adjusts API response codes for better consistency and reliability. The main focus is to ensure that any changes to a user's process runs are immediately reflected by invalidating their cache, and to align status codes and error handling across the API and backend.

**Cache Invalidation Improvements:**

* Added a per-user cache versioning system to invalidate all `latest_runs` cache entries for a user whenever a process run is created or updated, ensuring the frontend always receives up-to-date results. This is achieved via the new `_bump_user_cache_version` method and by including the version in the cache key. [[1]](diffhunk://#diff-859ae240ef13c2c8e8ce14a8072ba54e90d4776b9bab27fa001e01ce35bd9a0cR41-R65) [[2]](diffhunk://#diff-859ae240ef13c2c8e8ce14a8072ba54e90d4776b9bab27fa001e01ce35bd9a0cR179) [[3]](diffhunk://#diff-859ae240ef13c2c8e8ce14a8072ba54e90d4776b9bab27fa001e01ce35bd9a0cL186-R222)

**Error Handling and Status Normalization:**

* Normalized SDK status values so that the backend model uses `"error"` instead of `"failed"`, ensuring consistency in process run statuses.
* Updated the API response in `run` to return `HTTP_400_BAD_REQUEST` for both `"failed"` and `"error"` statuses, covering all error cases.

**API Response Code Adjustments:**

* Changed the `latest_runs` endpoint to return `400` instead of `500` for client-related errors, aligning with standard API practices.This pull request improves the handling and normalization of process run statuses, ensuring consistency between the SDK and the database model, and enhances frontend data freshness by invalidating relevant caches after a process run. The main changes are:

**Status normalization and error handling:**

* In `spadeapp/processes/service.py`, the status returned by the SDK is now normalized: if the SDK returns `"failed"`, it is mapped to the model's `ERROR` status, ensuring consistency in status representation.
* In `spadeapp/processes/api.py`, the API response logic was updated to treat both `"failed"` and `ERROR` statuses as errors, returning a `400 BAD REQUEST` in those cases.

**Cache invalidation for frontend updates:**

* After saving a new process run, the cache for the latest runs is invalidated so that the frontend immediately reflects the new run status.