### PR TITLE
Upgrade dependencies and improve coverage management (#537)

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -5,7 +5,7 @@ ipdb==0.13.13  # https://github.com/gotcha/ipdb
 
 # Testing
 # ------------------------------------------------------------------------------
-mypy>=2.0.0,<2.2.0  # https://github.com/python/mypy
+mypy>=2.2.0,<2.3.0  # https://github.com/python/mypy
 django-stubs[compatible-mypy]==6.0.6  # https://github.com/typeddjango/django-stubs
 djangorestframework-stubs[compatible-mypy]==3.17.0  # https://github.com/typeddjango/djangorestframework-stubs
 pytest==9.1.1  # https://github.com/pytest-dev/pytest
@@ -15,10 +15,10 @@ pytest-sugar==1.1.1  # https://github.com/Frozenball/pytest-sugar
 
 # Code quality
 # ------------------------------------------------------------------------------
-ruff==0.15.20  # https://github.com/astral-sh/ruff (replaces flake8, isort, pylint)
-coverage==7.15.0  # https://github.com/nedbat/coveragepy
+ruff==0.15.21  # https://github.com/astral-sh/ruff (replaces flake8, isort, pylint)
+coverage==7.15.1  # https://github.com/nedbat/coveragepy
 black==26.5.1  # https://github.com/psf/black
-djlint==1.40.3  # https://github.com/Riverside-Healthcare/djLint
+djlint==1.40.5  # https://github.com/Riverside-Healthcare/djLint
 pre-commit==4.6.0  # https://github.com/pre-commit/pre-commit
 # Django
 # ------------------------------------------------------------------------------

--- a/spadeapp/processes/api.py
+++ b/spadeapp/processes/api.py
@@ -74,7 +74,7 @@ class ProcessViewSet(AutoPermissionViewSetMixin, viewsets.ModelViewSet):
         request=serializers.ProcessRunParamsSerializer,
         responses={
             200: serializers.ProcessRunSerializer,
-            500: serializers.ProcessRunSerializer,
+            400: serializers.ProcessRunSerializer,
         },
     )
     @decorators.action(detail=True, methods=["post"], permission_classes=[PostRequiresViewPermission])
@@ -85,7 +85,9 @@ class ProcessViewSet(AutoPermissionViewSetMixin, viewsets.ModelViewSet):
         )
 
         return Response(
-            status=status.HTTP_200_OK if run.status != "failed" else status.HTTP_400_BAD_REQUEST,
+            status=status.HTTP_200_OK
+            if run.status not in ("failed", models.ProcessRun.Statuses.ERROR)
+            else status.HTTP_400_BAD_REQUEST,
             data=serializer.data,
         )
 

--- a/spadeapp/processes/service.py
+++ b/spadeapp/processes/service.py
@@ -39,12 +39,30 @@ class ProcessService:
         )
 
     @staticmethod
+    def _bump_user_cache_version(user_id) -> None:
+        """Increment the per-user cache version counter.
+
+        This effectively invalidates *all* ``latest_runs`` cache entries for the
+        given user regardless of which process-ID combination was cached, since
+        every new version produces a different cache key.
+        """
+        version_key = f"latest-runs-version:{user_id}"
+        try:
+            cache.incr(version_key)
+        except ValueError, NotImplementedError:
+            # ValueError: key does not exist yet.
+            # NotImplementedError: backend doesn't support atomic incr; fall back.
+            current = cache.get(version_key, 0) or 0
+            cache.set(version_key, int(current) + 1, timeout=86400 * 7)
+
+    @staticmethod
     def _get_latest_runs_cache_key(process_ids: list[int], request) -> str | None:
         if not process_ids:
             return None
 
         user_id = getattr(getattr(request, "user", None), "id", "anon")
-        return ":".join(["latest-process-runs", str(user_id), ",".join(map(str, sorted(process_ids)))])
+        version = cache.get(f"latest-runs-version:{user_id}", 0)
+        return ":".join(["latest-process-runs", str(user_id), str(version), ",".join(map(str, sorted(process_ids)))])
 
     @staticmethod
     def get_latest_runs_for_processes(processes: list[Process], request) -> dict[int, ProcessRun]:
@@ -158,6 +176,7 @@ class ProcessService:
             run.error_message = "Failed to parse user params as JSON"
             run.status = ProcessRun.Statuses.ERROR
             run.save()
+            ProcessService._bump_user_cache_version(user.id)
             return run
 
         try:
@@ -183,14 +202,24 @@ class ProcessService:
             run.result = result.result.value if result.result else None
             run.output = result.output
             run.error_message = result.error_message
-            run.status = result.status.value
+            # Normalize SDK status: the SDK uses "failed" but the model uses "error"
+            sdk_status = result.status.value
+            if sdk_status == "failed":
+                run.status = ProcessRun.Statuses.ERROR
+            else:
+                run.status = sdk_status
             run.save()
+            # Invalidate all latest_runs caches for this user so the frontend
+            # sees the new run immediately, regardless of which process-ID
+            # combination was cached.
+            ProcessService._bump_user_cache_version(user.id)
         except Exception as e:
             logger.exception(f"Error running process {process}")
             run.status = ProcessRun.Statuses.ERROR
             run.result = ProcessRun.Results.FAILED
             run.error_message = str(e)
             run.save()
+            ProcessService._bump_user_cache_version(user.id)
 
         return run
 


### PR DESCRIPTION
* [pre-commit.ci] pre-commit autoupdate (#255)

updates:
- [github.com/adamchainz/django-upgrade: 1.23.1 → 1.25.0](https://github.com/adamchainz/django-upgrade/compare/1.23.1...1.25.0)
- [github.com/astral-sh/ruff-pre-commit: v0.9.10 → v0.11.11](https://github.com/astral-sh/ruff-pre-commit/compare/v0.9.10...v0.11.11)



* Bump docker/build-push-action from 6.17.0 to 6.18.0 (#278)

Bumps [docker/build-push-action](https://github.com/docker/build-push-action) from 6.17.0 to 6.18.0.
- [Release notes](https://github.com/docker/build-push-action/releases)
- [Commits](https://github.com/docker/build-push-action/compare/v6.17.0...v6.18.0)

---
updated-dependencies:
- dependency-name: docker/build-push-action dependency-version: 6.18.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump pytest from 8.3.5 to 8.4.0 in /requirements (#281)

Bumps [pytest](https://github.com/pytest-dev/pytest) from 8.3.5 to 8.4.0.
- [Release notes](https://github.com/pytest-dev/pytest/releases)
- [Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst)
- [Commits](https://github.com/pytest-dev/pytest/compare/8.3.5...8.4.0)

---
updated-dependencies:
- dependency-name: pytest dependency-version: 8.4.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump argon2-cffi from 23.1.0 to 25.1.0 in /requirements (#282)

Bumps [argon2-cffi](https://github.com/hynek/argon2-cffi) from 23.1.0 to 25.1.0.
- [Release notes](https://github.com/hynek/argon2-cffi/releases)
- [Changelog](https://github.com/hynek/argon2-cffi/blob/main/CHANGELOG.md)
- [Commits](https://github.com/hynek/argon2-cffi/compare/23.1.0...25.1.0)

---
updated-dependencies:
- dependency-name: argon2-cffi dependency-version: 25.1.0 dependency-type: direct:production update-type: version-update:semver-major ...




* Bump python in /compose/production/django (#283)

Bumps python from 3.12.10-slim-bookworm to 3.12.11-slim-bookworm.

---
updated-dependencies:
- dependency-name: python dependency-version: 3.12.11-slim-bookworm dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump python in /compose/local/docs (#284)

Bumps python from 3.11.12-slim-bullseye to 3.11.13-slim-bullseye.

---
updated-dependencies:
- dependency-name: python dependency-version: 3.11.13-slim-bullseye dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump python in /compose/local/django (#285)

Bumps python from 3.12.10-slim-bookworm to 3.12.11-slim-bookworm.

---
updated-dependencies:
- dependency-name: python dependency-version: 3.12.11-slim-bookworm dependency-type: direct:production update-type: version-update:semver-patch ...




* [pre-commit.ci] pre-commit autoupdate (#280)

updates:
- [github.com/astral-sh/ruff-pre-commit: v0.11.11 → v0.11.12](https://github.com/astral-sh/ruff-pre-commit/compare/v0.11.11...v0.11.12)



* upgrade to Python 3.13, Django 5.2 and add a missing endpoint for email confirmation

* Bump coverage from 7.8.2 to 7.9.0 in /requirements (#286)

Bumps [coverage](https://github.com/nedbat/coveragepy) from 7.8.2 to 7.9.0.
- [Release notes](https://github.com/nedbat/coveragepy/releases)
- [Changelog](https://github.com/nedbat/coveragepy/blob/master/CHANGES.rst)
- [Commits](https://github.com/nedbat/coveragepy/compare/7.8.2...7.9.0)

---
updated-dependencies:
- dependency-name: coverage dependency-version: 7.9.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump coverage from 7.9.0 to 7.9.1 in /requirements (#287)

Bumps [coverage](https://github.com/nedbat/coveragepy) from 7.9.0 to 7.9.1.
- [Release notes](https://github.com/nedbat/coveragepy/releases)
- [Changelog](https://github.com/nedbat/coveragepy/blob/master/CHANGES.rst)
- [Commits](https://github.com/nedbat/coveragepy/compare/7.9.0...7.9.1)

---
updated-dependencies:
- dependency-name: coverage dependency-version: 7.9.1 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump django-coverage-plugin from 3.1.0 to 3.1.1 in /requirements (#288)

Bumps [django-coverage-plugin](https://github.com/nedbat/django_coverage_plugin) from 3.1.0 to 3.1.1.
- [Release notes](https://github.com/nedbat/django_coverage_plugin/releases)
- [Commits](https://github.com/nedbat/django_coverage_plugin/compare/v3.1.0...v3.1.1)

---
updated-dependencies:
- dependency-name: django-coverage-plugin dependency-version: 3.1.1 dependency-type: direct:production update-type: version-update:semver-patch ...




* Secrets and validataions (#289)

* add variables and variable sets

* simplify the data model

* improve logging in examples

* add support for data schemas and pandera validations

* bump dependencies

* fix schema validation

* Bump pytest from 8.4.0 to 8.4.1 in /requirements (#290)

Bumps [pytest](https://github.com/pytest-dev/pytest) from 8.4.0 to 8.4.1.
- [Release notes](https://github.com/pytest-dev/pytest/releases)
- [Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst)
- [Commits](https://github.com/pytest-dev/pytest/compare/8.4.0...8.4.1)

---
updated-dependencies:
- dependency-name: pytest dependency-version: 8.4.1 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump flake8 from 7.2.0 to 7.3.0 in /requirements (#291)

Bumps [flake8](https://github.com/pycqa/flake8) from 7.2.0 to 7.3.0.
- [Commits](https://github.com/pycqa/flake8/compare/7.2.0...7.3.0)

---
updated-dependencies:
- dependency-name: flake8 dependency-version: 7.3.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump coverage from 7.9.1 to 7.9.2 in /requirements (#293)

Bumps [coverage](https://github.com/nedbat/coveragepy) from 7.9.1 to 7.9.2.
- [Release notes](https://github.com/nedbat/coveragepy/releases)
- [Changelog](https://github.com/nedbat/coveragepy/blob/master/CHANGES.rst)
- [Commits](https://github.com/nedbat/coveragepy/compare/7.9.1...7.9.2)

---
updated-dependencies:
- dependency-name: coverage dependency-version: 7.9.2 dependency-type: direct:production update-type: version-update:semver-patch ...




* upgrade dependencies

* Bump djangorestframework-simplejwt from 5.5.0 to 5.5.1 in /requirements (#295)

Bumps [djangorestframework-simplejwt](https://github.com/jazzband/djangorestframework-simplejwt) from 5.5.0 to 5.5.1.
- [Release notes](https://github.com/jazzband/djangorestframework-simplejwt/releases)
- [Changelog](https://github.com/jazzband/djangorestframework-simplejwt/blob/master/CHANGELOG.md)
- [Commits](https://github.com/jazzband/djangorestframework-simplejwt/compare/v5.5.0...v5.5.1)

---
updated-dependencies:
- dependency-name: djangorestframework-simplejwt dependency-version: 5.5.1 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump coverage from 7.9.2 to 7.10.0 in /requirements (#296)

Bumps [coverage](https://github.com/nedbat/coveragepy) from 7.9.2 to 7.10.0.
- [Release notes](https://github.com/nedbat/coveragepy/releases)
- [Changelog](https://github.com/nedbat/coveragepy/blob/master/CHANGES.rst)
- [Commits](https://github.com/nedbat/coveragepy/compare/7.9.2...7.10.0)

---
updated-dependencies:
- dependency-name: coverage dependency-version: 7.10.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump coverage from 7.10.0 to 7.10.1 in /requirements (#297)

Bumps [coverage](https://github.com/nedbat/coveragepy) from 7.10.0 to 7.10.1.
- [Release notes](https://github.com/nedbat/coveragepy/releases)
- [Changelog](https://github.com/nedbat/coveragepy/blob/master/CHANGES.rst)
- [Commits](https://github.com/nedbat/coveragepy/compare/7.10.0...7.10.1)

---
updated-dependencies:
- dependency-name: coverage dependency-version: 7.10.1 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump django-anymail from 13.0 to 13.0.1 in /requirements (#298)

Bumps [django-anymail](https://github.com/anymail/django-anymail) from 13.0 to 13.0.1.
- [Release notes](https://github.com/anymail/django-anymail/releases)
- [Changelog](https://github.com/anymail/django-anymail/blob/main/CHANGELOG.rst)
- [Commits](https://github.com/anymail/django-anymail/compare/v13.0...v13.0.1)

---
updated-dependencies:
- dependency-name: django-anymail dependency-version: 13.0.1 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump django-debug-toolbar from 5.2.0 to 6.0.0 in /requirements (#299)

Bumps [django-debug-toolbar](https://github.com/django-commons/django-debug-toolbar) from 5.2.0 to 6.0.0.
- [Release notes](https://github.com/django-commons/django-debug-toolbar/releases)
- [Changelog](https://github.com/django-commons/django-debug-toolbar/blob/main/docs/changes.rst)
- [Commits](https://github.com/django-commons/django-debug-toolbar/compare/5.2.0...6.0.0)

---
updated-dependencies:
- dependency-name: django-debug-toolbar dependency-version: 6.0.0 dependency-type: direct:production update-type: version-update:semver-major ...




* assign returned runresult status to saved processrun

* disallow changing is_secret after variable creation (#300)

* disallow changing is_secret after variable creation

* remove init file in variables test

* fix tests

* fix calls to reverse in test

* fix tests

* update reverse urls

* fix reverse urls

* fix reverse calld

* fix import

* screw it

* add name as filterset field to variable

* Bump coverage from 7.10.1 to 7.10.2 in /requirements (#305)

Bumps [coverage](https://github.com/nedbat/coveragepy) from 7.10.1 to 7.10.2.
- [Release notes](https://github.com/nedbat/coveragepy/releases)
- [Changelog](https://github.com/nedbat/coveragepy/blob/master/CHANGES.rst)
- [Commits](https://github.com/nedbat/coveragepy/compare/7.10.1...7.10.2)

---
updated-dependencies:
- dependency-name: coverage dependency-version: 7.10.2 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump docker/metadata-action from 5.7.0 to 5.8.0 (#306)

Bumps [docker/metadata-action](https://github.com/docker/metadata-action) from 5.7.0 to 5.8.0.
- [Release notes](https://github.com/docker/metadata-action/releases)
- [Commits](https://github.com/docker/metadata-action/compare/v5.7.0...v5.8.0)

---
updated-dependencies:
- dependency-name: docker/metadata-action dependency-version: 5.8.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump docker/login-action from 3.4.0 to 3.5.0 (#307)

Bumps [docker/login-action](https://github.com/docker/login-action) from 3.4.0 to 3.5.0.
- [Release notes](https://github.com/docker/login-action/releases)
- [Commits](https://github.com/docker/login-action/compare/v3.4.0...v3.5.0)

---
updated-dependencies:
- dependency-name: docker/login-action dependency-version: 3.5.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump djangorestframework from 3.16.0 to 3.16.1 in /requirements (#308)

Bumps [djangorestframework](https://github.com/encode/django-rest-framework) from 3.16.0 to 3.16.1.
- [Release notes](https://github.com/encode/django-rest-framework/releases)
- [Commits](https://github.com/encode/django-rest-framework/compare/3.16.0...3.16.1)

---
updated-dependencies:
- dependency-name: djangorestframework dependency-version: 3.16.1 dependency-type: direct:production update-type: version-update:semver-patch ...




* include variable sets when retrieving process history

* Bump pre-commit from 4.2.0 to 4.3.0 in /requirements (#309)

Bumps [pre-commit](https://github.com/pre-commit/pre-commit) from 4.2.0 to 4.3.0.
- [Release notes](https://github.com/pre-commit/pre-commit/releases)
- [Changelog](https://github.com/pre-commit/pre-commit/blob/main/CHANGELOG.md)
- [Commits](https://github.com/pre-commit/pre-commit/compare/v4.2.0...v4.3.0)

---
updated-dependencies:
- dependency-name: pre-commit dependency-version: 4.3.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump coverage from 7.10.2 to 7.10.3 in /requirements (#310)

Bumps [coverage](https://github.com/nedbat/coveragepy) from 7.10.2 to 7.10.3.
- [Release notes](https://github.com/nedbat/coveragepy/releases)
- [Changelog](https://github.com/nedbat/coveragepy/blob/master/CHANGES.rst)
- [Commits](https://github.com/nedbat/coveragepy/compare/7.10.2...7.10.3)

---
updated-dependencies:
- dependency-name: coverage dependency-version: 7.10.3 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump actions/checkout from 4 to 5 (#312)

Bumps [actions/checkout](https://github.com/actions/checkout) from 4 to 5.
- [Release notes](https://github.com/actions/checkout/releases)
- [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [Commits](https://github.com/actions/checkout/compare/v4...v5)

---
updated-dependencies:
- dependency-name: actions/checkout dependency-version: '5' dependency-type: direct:production update-type: version-update:semver-major ...




* Bump coverage from 7.10.3 to 7.10.4 in /requirements (#313)

Bumps [coverage](https://github.com/nedbat/coveragepy) from 7.10.3 to 7.10.4.
- [Release notes](https://github.com/nedbat/coveragepy/releases)
- [Changelog](https://github.com/nedbat/coveragepy/blob/master/CHANGES.rst)
- [Commits](https://github.com/nedbat/coveragepy/compare/7.10.3...7.10.4)

---
updated-dependencies:
- dependency-name: coverage dependency-version: 7.10.4 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump pytest-sugar from 1.0.0 to 1.1.0 in /requirements (#314)

Bumps [pytest-sugar](https://github.com/Teemu/pytest-sugar) from 1.0.0 to 1.1.0.
- [Release notes](https://github.com/Teemu/pytest-sugar/releases)
- [Changelog](https://github.com/Teemu/pytest-sugar/blob/main/CHANGES.rst)
- [Commits](https://github.com/Teemu/pytest-sugar/compare/v1.0.0...v1.1.0)

---
updated-dependencies:
- dependency-name: pytest-sugar dependency-version: 1.1.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump actions/upload-pages-artifact from 3 to 4 (#316)

Bumps [actions/upload-pages-artifact](https://github.com/actions/upload-pages-artifact) from 3 to 4.
- [Release notes](https://github.com/actions/upload-pages-artifact/releases)
- [Commits](https://github.com/actions/upload-pages-artifact/compare/v3...v4)

---
updated-dependencies:
- dependency-name: actions/upload-pages-artifact dependency-version: '4' dependency-type: direct:production update-type: version-update:semver-major ...




* Bump pytest-sugar from 1.1.0 to 1.1.1 in /requirements (#317)

Bumps [pytest-sugar](https://github.com/Teemu/pytest-sugar) from 1.1.0 to 1.1.1.
- [Release notes](https://github.com/Teemu/pytest-sugar/releases)
- [Changelog](https://github.com/Teemu/pytest-sugar/blob/main/CHANGES.rst)
- [Commits](https://github.com/Teemu/pytest-sugar/compare/v1.1.0...v1.1.1)

---
updated-dependencies:
- dependency-name: pytest-sugar dependency-version: 1.1.1 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump coverage from 7.10.4 to 7.10.5 in /requirements (#318)

Bumps [coverage](https://github.com/nedbat/coveragepy) from 7.10.4 to 7.10.5.
- [Release notes](https://github.com/nedbat/coveragepy/releases)
- [Changelog](https://github.com/nedbat/coveragepy/blob/master/CHANGES.rst)
- [Commits](https://github.com/nedbat/coveragepy/compare/7.10.4...7.10.5)

---
updated-dependencies:
- dependency-name: coverage dependency-version: 7.10.5 dependency-type: direct:production update-type: version-update:semver-patch ...




* upgrade dependencies

* Bump coverage from 7.10.5 to 7.10.6 in /requirements (#319)

Bumps [coverage](https://github.com/nedbat/coveragepy) from 7.10.5 to 7.10.6.
- [Release notes](https://github.com/nedbat/coveragepy/releases)
- [Changelog](https://github.com/nedbat/coveragepy/blob/master/CHANGES.rst)
- [Commits](https://github.com/nedbat/coveragepy/compare/7.10.5...7.10.6)

---
updated-dependencies:
- dependency-name: coverage dependency-version: 7.10.6 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump django-anymail from 13.0.1 to 13.1 in /requirements (#320)

Bumps [django-anymail](https://github.com/anymail/django-anymail) from 13.0.1 to 13.1.
- [Release notes](https://github.com/anymail/django-anymail/releases)
- [Changelog](https://github.com/anymail/django-anymail/blob/main/CHANGELOG.rst)
- [Commits](https://github.com/anymail/django-anymail/compare/v13.0.1...v13.1)

---
updated-dependencies:
- dependency-name: django-anymail dependency-version: '13.1' dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump actions/setup-node from 4 to 5 (#321)

Bumps [actions/setup-node](https://github.com/actions/setup-node) from 4 to 5.
- [Release notes](https://github.com/actions/setup-node/releases)
- [Commits](https://github.com/actions/setup-node/compare/v4...v5)

---
updated-dependencies:
- dependency-name: actions/setup-node dependency-version: '5' dependency-type: direct:production update-type: version-update:semver-major ...




* Bump pytest from 8.4.1 to 8.4.2 in /requirements (#322)

Bumps [pytest](https://github.com/pytest-dev/pytest) from 8.4.1 to 8.4.2.
- [Release notes](https://github.com/pytest-dev/pytest/releases)
- [Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst)
- [Commits](https://github.com/pytest-dev/pytest/compare/8.4.1...8.4.2)

---
updated-dependencies:
- dependency-name: pytest dependency-version: 8.4.2 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump django-cors-headers from 4.7.0 to 4.8.0 in /requirements (#323)

Bumps [django-cors-headers](https://github.com/adamchainz/django-cors-headers) from 4.7.0 to 4.8.0.
- [Changelog](https://github.com/adamchainz/django-cors-headers/blob/main/CHANGELOG.rst)
- [Commits](https://github.com/adamchainz/django-cors-headers/compare/4.7.0...4.8.0)

---
updated-dependencies:
- dependency-name: django-cors-headers dependency-version: 4.8.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump whitenoise from 6.9.0 to 6.10.0 in /requirements (#325)

Bumps [whitenoise](https://github.com/evansd/whitenoise) from 6.9.0 to 6.10.0.
- [Changelog](https://github.com/evansd/whitenoise/blob/main/docs/changelog.rst)
- [Commits](https://github.com/evansd/whitenoise/compare/6.9.0...6.10.0)

---
updated-dependencies:
- dependency-name: whitenoise dependency-version: 6.10.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump psycopg[binary] from 3.2.9 to 3.2.10 in /requirements (#324)

Bumps [psycopg[binary]](https://github.com/psycopg/psycopg) from 3.2.9 to 3.2.10.
- [Changelog](https://github.com/psycopg/psycopg/blob/master/docs/news.rst)
- [Commits](https://github.com/psycopg/psycopg/compare/3.2.9...3.2.10)

---
updated-dependencies:
- dependency-name: psycopg[binary] dependency-version: 3.2.10 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump whitenoise from 6.10.0 to 6.11.0 in /requirements (#326)

Bumps [whitenoise](https://github.com/evansd/whitenoise) from 6.10.0 to 6.11.0.
- [Changelog](https://github.com/evansd/whitenoise/blob/main/docs/changelog.rst)
- [Commits](https://github.com/evansd/whitenoise/compare/6.10.0...6.11.0)

---
updated-dependencies:
- dependency-name: whitenoise dependency-version: 6.11.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump black from 25.1.0 to 25.9.0 in /requirements (#328)

Bumps [black](https://github.com/psf/black) from 25.1.0 to 25.9.0.
- [Release notes](https://github.com/psf/black/releases)
- [Changelog](https://github.com/psf/black/blob/main/CHANGES.md)
- [Commits](https://github.com/psf/black/compare/25.1.0...25.9.0)

---
updated-dependencies:
- dependency-name: black dependency-version: 25.9.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump coverage from 7.10.6 to 7.10.7 in /requirements (#329)

Bumps [coverage](https://github.com/nedbat/coveragepy) from 7.10.6 to 7.10.7.
- [Release notes](https://github.com/nedbat/coveragepy/releases)
- [Changelog](https://github.com/nedbat/coveragepy/blob/master/CHANGES.rst)
- [Commits](https://github.com/nedbat/coveragepy/compare/7.10.6...7.10.7)

---
updated-dependencies:
- dependency-name: coverage dependency-version: 7.10.7 dependency-type: direct:production update-type: version-update:semver-patch ...




* [pre-commit.ci] pre-commit autoupdate (#294)

updates:
- [github.com/adamchainz/django-upgrade: 1.26.0 → 1.28.0](https://github.com/adamchainz/django-upgrade/compare/1.26.0...1.28.0)
- [github.com/astral-sh/ruff-pre-commit: v0.12.10 → v0.13.1](https://github.com/astral-sh/ruff-pre-commit/compare/v0.12.10...v0.13.1)



* upgrade dependencies

* Bump docker/login-action from 3.5.0 to 3.6.0 (#333)

Bumps [docker/login-action](https://github.com/docker/login-action) from 3.5.0 to 3.6.0.
- [Release notes](https://github.com/docker/login-action/releases)
- [Commits](https://github.com/docker/login-action/compare/v3.5.0...v3.6.0)

---
updated-dependencies:
- dependency-name: docker/login-action dependency-version: 3.6.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump django-coverage-plugin from 3.1.1 to 3.2.0 in /requirements (#334)

Bumps [django-coverage-plugin](https://github.com/nedbat/django_coverage_plugin) from 3.1.1 to 3.2.0.
- [Release notes](https://github.com/nedbat/django_coverage_plugin/releases)
- [Commits](https://github.com/nedbat/django_coverage_plugin/compare/v3.1.1...v3.2.0)

---
updated-dependencies:
- dependency-name: django-coverage-plugin dependency-version: 3.2.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump djangorestframework-stubs[compatible-mypy] in /requirements (#336)

Bumps [djangorestframework-stubs[compatible-mypy]](https://github.com/sponsors/typeddjango) from 3.16.3 to 3.16.4.
- [Commits](https://github.com/sponsors/typeddjango/commits)

---
updated-dependencies:
- dependency-name: djangorestframework-stubs[compatible-mypy] dependency-version: 3.16.4 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump django from 5.2.6 to 5.2.7 in /requirements (#337)

Bumps [django](https://github.com/django/django) from 5.2.6 to 5.2.7.
- [Commits](https://github.com/django/django/compare/5.2.6...5.2.7)

---
updated-dependencies:
- dependency-name: django dependency-version: 5.2.7 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump django-stubs[compatible-mypy] from 5.2.5 to 5.2.6 in /requirements (#338)

Bumps [django-stubs[compatible-mypy]](https://github.com/sponsors/typeddjango) from 5.2.5 to 5.2.6.
- [Commits](https://github.com/sponsors/typeddjango/commits)

---
updated-dependencies:
- dependency-name: django-stubs[compatible-mypy] dependency-version: 5.2.6 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump django-stubs[compatible-mypy] from 5.2.6 to 5.2.7 in /requirements (#339)

Bumps [django-stubs[compatible-mypy]](https://github.com/sponsors/typeddjango) from 5.2.6 to 5.2.7.
- [Commits](https://github.com/sponsors/typeddjango/commits)

---
updated-dependencies:
- dependency-name: django-stubs[compatible-mypy] dependency-version: 5.2.7 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump actions/setup-node from 5 to 6 (#341)

Bumps [actions/setup-node](https://github.com/actions/setup-node) from 5 to 6.
- [Release notes](https://github.com/actions/setup-node/releases)
- [Commits](https://github.com/actions/setup-node/compare/v5...v6)

---
updated-dependencies:
- dependency-name: actions/setup-node dependency-version: '6' dependency-type: direct:production update-type: version-update:semver-major ...




* Bump coverage from 7.10.7 to 7.11.0 in /requirements (#342)

Bumps [coverage](https://github.com/nedbat/coveragepy) from 7.10.7 to 7.11.0.
- [Release notes](https://github.com/nedbat/coveragepy/releases)
- [Changelog](https://github.com/nedbat/coveragepy/blob/master/CHANGES.rst)
- [Commits](https://github.com/nedbat/coveragepy/compare/7.10.7...7.11.0)

---
updated-dependencies:
- dependency-name: coverage dependency-version: 7.11.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump psycopg[binary] from 3.2.10 to 3.2.11 in /requirements (#343)

Bumps [psycopg[binary]](https://github.com/psycopg/psycopg) from 3.2.10 to 3.2.11.
- [Changelog](https://github.com/psycopg/psycopg/blob/master/docs/news.rst)
- [Commits](https://github.com/psycopg/psycopg/compare/3.2.10...3.2.11)

---
updated-dependencies:
- dependency-name: psycopg[binary] dependency-version: 3.2.11 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump djangorestframework-stubs[compatible-mypy] in /requirements (#344)

Bumps [djangorestframework-stubs[compatible-mypy]](https://github.com/sponsors/typeddjango) from 3.16.4 to 3.16.5.
- [Commits](https://github.com/sponsors/typeddjango/commits)

---
updated-dependencies:
- dependency-name: djangorestframework-stubs[compatible-mypy] dependency-version: 3.16.5 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump flake8-isort from 6.1.2 to 7.0.0 in /requirements (#345)

Bumps [flake8-isort](https://github.com/gforcada/flake8-isort) from 6.1.2 to 7.0.0.
- [Changelog](https://github.com/gforcada/flake8-isort/blob/main/CHANGES.rst)
- [Commits](https://github.com/gforcada/flake8-isort/compare/6.1.2...7.0.0)

---
updated-dependencies:
- dependency-name: flake8-isort dependency-version: 7.0.0 dependency-type: direct:production update-type: version-update:semver-major ...




* Bump psycopg[binary] from 3.2.11 to 3.2.12 in /requirements (#346)

Bumps [psycopg[binary]](https://github.com/psycopg/psycopg) from 3.2.11 to 3.2.12.
- [Changelog](https://github.com/psycopg/psycopg/blob/master/docs/news.rst)
- [Commits](https://github.com/psycopg/psycopg/compare/3.2.11...3.2.12)

---
updated-dependencies:
- dependency-name: psycopg[binary] dependency-version: 3.2.12 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump django-debug-toolbar from 6.0.0 to 6.1.0 in /requirements (#347)

Bumps [django-debug-toolbar](https://github.com/django-commons/django-debug-toolbar) from 6.0.0 to 6.1.0.
- [Release notes](https://github.com/django-commons/django-debug-toolbar/releases)
- [Changelog](https://github.com/django-commons/django-debug-toolbar/blob/main/docs/changes.rst)
- [Commits](https://github.com/django-commons/django-debug-toolbar/compare/6.0.0...6.1.0)

---
updated-dependencies:
- dependency-name: django-debug-toolbar dependency-version: 6.1.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump docker/metadata-action from 5.8.0 to 5.9.0 (#348)

Bumps [docker/metadata-action](https://github.com/docker/metadata-action) from 5.8.0 to 5.9.0.
- [Release notes](https://github.com/docker/metadata-action/releases)
- [Commits](https://github.com/docker/metadata-action/compare/v5.8.0...v5.9.0)

---
updated-dependencies:
- dependency-name: docker/metadata-action dependency-version: 5.9.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump django from 5.2.7 to 5.2.8 in /requirements (#349)

Bumps [django](https://github.com/django/django) from 5.2.7 to 5.2.8.
- [Commits](https://github.com/django/django/compare/5.2.7...5.2.8)

---
updated-dependencies:
- dependency-name: django dependency-version: 5.2.8 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump black from 25.9.0 to 25.11.0 in /requirements (#350)

Bumps [black](https://github.com/psf/black) from 25.9.0 to 25.11.0.
- [Release notes](https://github.com/psf/black/releases)
- [Changelog](https://github.com/psf/black/blob/main/CHANGES.md)
- [Commits](https://github.com/psf/black/compare/25.9.0...25.11.0)

---
updated-dependencies:
- dependency-name: black dependency-version: 25.11.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump pytest from 8.4.2 to 9.0.0 in /requirements (#353)

Bumps [pytest](https://github.com/pytest-dev/pytest) from 8.4.2 to 9.0.0.
- [Release notes](https://github.com/pytest-dev/pytest/releases)
- [Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst)
- [Commits](https://github.com/pytest-dev/pytest/compare/8.4.2...9.0.0)

---
updated-dependencies:
- dependency-name: pytest dependency-version: 9.0.0 dependency-type: direct:production update-type: version-update:semver-major ...




* Bump pre-commit from 4.3.0 to 4.4.0 in /requirements (#351)

Bumps [pre-commit](https://github.com/pre-commit/pre-commit) from 4.3.0 to 4.4.0.
- [Release notes](https://github.com/pre-commit/pre-commit/releases)
- [Changelog](https://github.com/pre-commit/pre-commit/blob/main/CHANGELOG.md)
- [Commits](https://github.com/pre-commit/pre-commit/compare/v4.3.0...v4.4.0)

---
updated-dependencies:
- dependency-name: pre-commit dependency-version: 4.4.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump coverage from 7.11.0 to 7.11.3 in /requirements (#352)

Bumps [coverage](https://github.com/coveragepy/coveragepy) from 7.11.0 to 7.11.3.
- [Release notes](https://github.com/coveragepy/coveragepy/releases)
- [Changelog](https://github.com/coveragepy/coveragepy/blob/main/CHANGES.rst)
- [Commits](https://github.com/coveragepy/coveragepy/compare/7.11.0...7.11.3)

---
updated-dependencies:
- dependency-name: coverage dependency-version: 7.11.3 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump pytest from 9.0.0 to 9.0.1 in /requirements (#354)

Bumps [pytest](https://github.com/pytest-dev/pytest) from 9.0.0 to 9.0.1.
- [Release notes](https://github.com/pytest-dev/pytest/releases)
- [Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst)
- [Commits](https://github.com/pytest-dev/pytest/compare/9.0.0...9.0.1)

---
updated-dependencies:
- dependency-name: pytest dependency-version: 9.0.1 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump coverage from 7.11.3 to 7.12.0 in /requirements (#355)

Bumps [coverage](https://github.com/coveragepy/coveragepy) from 7.11.3 to 7.12.0.
- [Release notes](https://github.com/coveragepy/coveragepy/releases)
- [Changelog](https://github.com/coveragepy/coveragepy/blob/main/CHANGES.rst)
- [Commits](https://github.com/coveragepy/coveragepy/compare/7.11.3...7.12.0)

---
updated-dependencies:
- dependency-name: coverage dependency-version: 7.12.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump actions/checkout from 5 to 6 (#356)

Bumps [actions/checkout](https://github.com/actions/checkout) from 5 to 6.
- [Release notes](https://github.com/actions/checkout/releases)
- [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [Commits](https://github.com/actions/checkout/compare/v5...v6)

---
updated-dependencies:
- dependency-name: actions/checkout dependency-version: '6' dependency-type: direct:production update-type: version-update:semver-major ...




* Bump psycopg[binary] from 3.2.12 to 3.2.13 in /requirements (#357)

Bumps [psycopg[binary]](https://github.com/psycopg/psycopg) from 3.2.12 to 3.2.13.
- [Changelog](https://github.com/psycopg/psycopg/blob/master/docs/news.rst)
- [Commits](https://github.com/psycopg/psycopg/compare/3.2.12...3.2.13)

---
updated-dependencies:
- dependency-name: psycopg[binary] dependency-version: 3.2.13 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump docker/metadata-action from 5.9.0 to 5.10.0 (#359)

Bumps [docker/metadata-action](https://github.com/docker/metadata-action) from 5.9.0 to 5.10.0.
- [Release notes](https://github.com/docker/metadata-action/releases)
- [Commits](https://github.com/docker/metadata-action/compare/v5.9.0...v5.10.0)

---
updated-dependencies:
- dependency-name: docker/metadata-action dependency-version: 5.10.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump werkzeug[watchdog] from 3.1.3 to 3.1.4 in /requirements (#360)

Bumps [werkzeug[watchdog]](https://github.com/pallets/werkzeug) from 3.1.3 to 3.1.4.
- [Release notes](https://github.com/pallets/werkzeug/releases)
- [Changelog](https://github.com/pallets/werkzeug/blob/main/CHANGES.rst)
- [Commits](https://github.com/pallets/werkzeug/compare/3.1.3...3.1.4)

---
updated-dependencies:
- dependency-name: werkzeug[watchdog] dependency-version: 3.1.4 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump django-stubs[compatible-mypy] from 5.2.7 to 5.2.8 in /requirements (#361)

Bumps [django-stubs[compatible-mypy]](https://github.com/sponsors/typeddjango) from 5.2.7 to 5.2.8.
- [Commits](https://github.com/sponsors/typeddjango/commits)

---
updated-dependencies:
- dependency-name: django-stubs[compatible-mypy] dependency-version: 5.2.8 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump python in /compose/production/django (#363)

Bumps python from 3.13-slim-bookworm to 3.13.10-slim-bookworm.

---
updated-dependencies:
- dependency-name: python dependency-version: 3.13.10-slim-bookworm dependency-type: direct:production ...




* Bump psycopg[binary] from 3.2.13 to 3.3.1 in /requirements (#365)

Bumps [psycopg[binary]](https://github.com/psycopg/psycopg) from 3.2.13 to 3.3.1.
- [Changelog](https://github.com/psycopg/psycopg/blob/master/docs/news.rst)
- [Commits](https://github.com/psycopg/psycopg/compare/3.2.13...3.3.1)

---
updated-dependencies:
- dependency-name: psycopg[binary] dependency-version: 3.3.1 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump django from 5.2.8 to 5.2.9 in /requirements (#366)

Bumps [django](https://github.com/django/django) from 5.2.8 to 5.2.9.
- [Commits](https://github.com/django/django/compare/5.2.8...5.2.9)

---
updated-dependencies:
- dependency-name: django dependency-version: 5.2.9 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump django from 5.2.9 to 6.0 in /requirements (#367)

Bumps [django](https://github.com/django/django) from 5.2.9 to 6.0.
- [Commits](https://github.com/django/django/compare/5.2.9...6.0)

---
updated-dependencies:
- dependency-name: django dependency-version: '6.0' dependency-type: direct:production update-type: version-update:semver-major ...




* Bump psycopg[binary] from 3.3.1 to 3.3.2 in /requirements (#369)

Bumps [psycopg[binary]](https://github.com/psycopg/psycopg) from 3.3.1 to 3.3.2.
- [Changelog](https://github.com/psycopg/psycopg/blob/master/docs/news.rst)
- [Commits](https://github.com/psycopg/psycopg/compare/3.3.1...3.3.2)

---
updated-dependencies:
- dependency-name: psycopg[binary] dependency-version: 3.3.2 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump pytest from 9.0.1 to 9.0.2 in /requirements (#370)

Bumps [pytest](https://github.com/pytest-dev/pytest) from 9.0.1 to 9.0.2.
- [Release notes](https://github.com/pytest-dev/pytest/releases)
- [Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst)
- [Commits](https://github.com/pytest-dev/pytest/compare/9.0.1...9.0.2)

---
updated-dependencies:
- dependency-name: pytest dependency-version: 9.0.2 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump djangorestframework-stubs[compatible-mypy] in /requirements (#368)

Bumps [djangorestframework-stubs[compatible-mypy]](https://github.com/sponsors/typeddjango) from 3.16.5 to 3.16.6.
- [Commits](https://github.com/sponsors/typeddjango/commits)

---
updated-dependencies:
- dependency-name: djangorestframework-stubs[compatible-mypy] dependency-version: 3.16.6 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump python in /compose/production/django (#372)

Bumps python from 3.13.10-slim-bookworm to 3.13.11-slim-bookworm.

---
updated-dependencies:
- dependency-name: python dependency-version: 3.13.11-slim-bookworm dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump coverage from 7.12.0 to 7.13.0 in /requirements (#373)

Bumps [coverage](https://github.com/coveragepy/coveragepy) from 7.12.0 to 7.13.0.
- [Release notes](https://github.com/coveragepy/coveragepy/releases)
- [Changelog](https://github.com/coveragepy/coveragepy/blob/main/CHANGES.rst)
- [Commits](https://github.com/coveragepy/coveragepy/compare/7.12.0...7.13.0)

---
updated-dependencies:
- dependency-name: coverage dependency-version: 7.13.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump black from 25.11.0 to 25.12.0 in /requirements (#371)

Bumps [black](https://github.com/psf/black) from 25.11.0 to 25.12.0.
- [Release notes](https://github.com/psf/black/releases)
- [Changelog](https://github.com/psf/black/blob/main/CHANGES.md)
- [Commits](https://github.com/psf/black/compare/25.11.0...25.12.0)

---
updated-dependencies:
- dependency-name: black dependency-version: 25.12.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump pre-commit from 4.4.0 to 4.5.0 in /requirements (#358)

Bumps [pre-commit](https://github.com/pre-commit/pre-commit) from 4.4.0 to 4.5.0.
- [Release notes](https://github.com/pre-commit/pre-commit/releases)
- [Changelog](https://github.com/pre-commit/pre-commit/blob/main/CHANGELOG.md)
- [Commits](https://github.com/pre-commit/pre-commit/compare/v4.4.0...v4.5.0)

---
updated-dependencies:
- dependency-name: pre-commit dependency-version: 4.5.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* added testing readme

* dependancy checks

* Bump django from 5.2.3 to 6.0 in /requirements (#374)

Bumps [django](https://github.com/django/django) from 5.2.3 to 6.0.
- [Commits](https://github.com/django/django/compare/5.2.3...6.0)

---
updated-dependencies:
- dependency-name: django dependency-version: '6.0' dependency-type: direct:production update-type: version-update:semver-major ...




* Bump pre-commit from 4.5.0 to 4.5.1 in /requirements (#375)

Bumps [pre-commit](https://github.com/pre-commit/pre-commit) from 4.5.0 to 4.5.1.
- [Release notes](https://github.com/pre-commit/pre-commit/releases)
- [Changelog](https://github.com/pre-commit/pre-commit/blob/main/CHANGELOG.md)
- [Commits](https://github.com/pre-commit/pre-commit/compare/v4.5.0...v4.5.1)

---
updated-dependencies:
- dependency-name: pre-commit dependency-version: 4.5.1 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump django-anymail from 13.1 to 14.0 in /requirements (#376)

Bumps [django-anymail](https://github.com/anymail/django-anymail) from 13.1 to 14.0.
- [Release notes](https://github.com/anymail/django-anymail/releases)
- [Changelog](https://github.com/anymail/django-anymail/blob/main/CHANGELOG.rst)
- [Commits](https://github.com/anymail/django-anymail/compare/v13.1...v14.0)

---
updated-dependencies:
- dependency-name: django-anymail dependency-version: '14.0' dependency-type: direct:production update-type: version-update:semver-major ...




* Bump coverage from 7.13.0 to 7.13.1 in /requirements (#377)

Bumps [coverage](https://github.com/coveragepy/coveragepy) from 7.13.0 to 7.13.1.
- [Release notes](https://github.com/coveragepy/coveragepy/releases)
- [Changelog](https://github.com/coveragepy/coveragepy/blob/main/CHANGES.rst)
- [Commits](https://github.com/coveragepy/coveragepy/compare/7.13.0...7.13.1)

---
updated-dependencies:
- dependency-name: coverage dependency-version: 7.13.1 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump pylint-django from 2.6.1 to 2.7.0 in /requirements (#378)

Bumps [pylint-django](https://github.com/pylint-dev/pylint-django) from 2.6.1 to 2.7.0.
- [Release notes](https://github.com/pylint-dev/pylint-django/releases)
- [Changelog](https://github.com/pylint-dev/pylint-django/blob/master/CHANGELOG.rst)
- [Commits](https://github.com/pylint-dev/pylint-django/compare/v2.6.1...v2.7.0)

---
updated-dependencies:
- dependency-name: pylint-django dependency-version: 2.7.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump django from 6.0 to 6.0.1 in /requirements (#379)

Bumps [django](https://github.com/django/django) from 6.0 to 6.0.1.
- [Commits](https://github.com/django/django/compare/6.0...6.0.1)

---
updated-dependencies:
- dependency-name: django dependency-version: 6.0.1 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump werkzeug[watchdog] from 3.1.4 to 3.1.5 in /requirements (#380)

Bumps [werkzeug[watchdog]](https://github.com/pallets/werkzeug) from 3.1.4 to 3.1.5.
- [Release notes](https://github.com/pallets/werkzeug/releases)
- [Changelog](https://github.com/pallets/werkzeug/blob/main/CHANGES.rst)
- [Commits](https://github.com/pallets/werkzeug/compare/3.1.4...3.1.5)

---
updated-dependencies:
- dependency-name: werkzeug[watchdog] dependency-version: 3.1.5 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump dj-rest-auth[with_social] from 7.0.1 to 7.0.2 in /requirements (#381)

Bumps [dj-rest-auth[with_social]](https://github.com/iMerica/dj-rest-auth) from 7.0.1 to 7.0.2.
- [Release notes](https://github.com/iMerica/dj-rest-auth/releases)
- [Commits](https://github.com/iMerica/dj-rest-auth/compare/7.0.1...7.0.2)

---
updated-dependencies:
- dependency-name: dj-rest-auth[with_social] dependency-version: 7.0.2 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump djangorestframework-stubs[compatible-mypy] in /requirements (#382)

Bumps [djangorestframework-stubs[compatible-mypy]](https://github.com/sponsors/typeddjango) from 3.16.6 to 3.16.7.
- [Commits](https://github.com/sponsors/typeddjango/commits)

---
updated-dependencies:
- dependency-name: djangorestframework-stubs[compatible-mypy] dependency-version: 3.16.7 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump black from 25.12.0 to 26.1.0 in /requirements (#383)

Bumps [black](https://github.com/psf/black) from 25.12.0 to 26.1.0.
- [Release notes](https://github.com/psf/black/releases)
- [Changelog](https://github.com/psf/black/blob/main/CHANGES.md)
- [Commits](https://github.com/psf/black/compare/25.12.0...26.1.0)

---
updated-dependencies:
- dependency-name: black dependency-version: 26.1.0 dependency-type: direct:production update-type: version-update:semver-major ...




* Bump django-debug-toolbar from 6.1.0 to 6.2.0 in /requirements (#384)

Bumps [django-debug-toolbar](https://github.com/django-commons/django-debug-toolbar) from 6.1.0 to 6.2.0.
- [Release notes](https://github.com/django-commons/django-debug-toolbar/releases)
- [Changelog](https://github.com/django-commons/django-debug-toolbar/blob/main/docs/changes.rst)
- [Commits](https://github.com/django-commons/django-debug-toolbar/compare/6.1.0...6.2.0)

---
updated-dependencies:
- dependency-name: django-debug-toolbar dependency-version: 6.2.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump gunicorn from 23.0.0 to 24.0.0 in /requirements (#386)

Bumps [gunicorn](https://github.com/benoitc/gunicorn) from 23.0.0 to 24.0.0.
- [Release notes](https://github.com/benoitc/gunicorn/releases)
- [Commits](https://github.com/benoitc/gunicorn/compare/23.0.0...24.0.0)

---
updated-dependencies:
- dependency-name: gunicorn dependency-version: 24.0.0 dependency-type: direct:production update-type: version-update:semver-major ...




* Bump coverage from 7.13.1 to 7.13.2 in /requirements (#387)

Bumps [coverage](https://github.com/coveragepy/coveragepy) from 7.13.1 to 7.13.2.
- [Release notes](https://github.com/coveragepy/coveragepy/releases)
- [Changelog](https://github.com/coveragepy/coveragepy/blob/main/CHANGES.rst)
- [Commits](https://github.com/coveragepy/coveragepy/compare/7.13.1...7.13.2)

---
updated-dependencies:
- dependency-name: coverage dependency-version: 7.13.2 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump gunicorn from 24.0.0 to 24.1.1 in /requirements (#388)

Bumps [gunicorn](https://github.com/benoitc/gunicorn) from 24.0.0 to 24.1.1.
- [Release notes](https://github.com/benoitc/gunicorn/releases)
- [Commits](https://github.com/benoitc/gunicorn/compare/24.0.0...24.1.1)

---
updated-dependencies:
- dependency-name: gunicorn dependency-version: 24.1.1 dependency-type: direct:production update-type: version-update:semver-minor ...




* revert django to version 5

* include frictionless in pandera install

* Bump django from 5.2.10 to 6.0.1 in /requirements (#389)

Bumps [django](https://github.com/django/django) from 5.2.10 to 6.0.1.
- [Commits](https://github.com/django/django/compare/5.2.10...6.0.1)

---
updated-dependencies:
- dependency-name: django dependency-version: 6.0.1 dependency-type: direct:production update-type: version-update:semver-major ...




* Bump docker/login-action from 3.6.0 to 3.7.0 (#390)

Bumps [docker/login-action](https://github.com/docker/login-action) from 3.6.0 to 3.7.0.
- [Release notes](https://github.com/docker/login-action/releases)
- [Commits](https://github.com/docker/login-action/compare/v3.6.0...v3.7.0)

---
updated-dependencies:
- dependency-name: docker/login-action dependency-version: 3.7.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump gunicorn from 24.1.1 to 25.0.0 in /requirements (#391)

Bumps [gunicorn](https://github.com/benoitc/gunicorn) from 24.1.1 to 25.0.0.
- [Release notes](https://github.com/benoitc/gunicorn/releases)
- [Commits](https://github.com/benoitc/gunicorn/compare/24.1.1...25.0.0)

---
updated-dependencies:
- dependency-name: gunicorn dependency-version: 25.0.0 dependency-type: direct:production update-type: version-update:semver-major ...




* Bump gunicorn from 25.0.0 to 25.0.1 in /requirements (#392)

Bumps [gunicorn](https://github.com/benoitc/gunicorn) from 25.0.0 to 25.0.1.
- [Release notes](https://github.com/benoitc/gunicorn/releases)
- [Commits](https://github.com/benoitc/gunicorn/compare/25.0.0...25.0.1)

---
updated-dependencies:
- dependency-name: gunicorn dependency-version: 25.0.1 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump django from 6.0.1 to 6.0.2 in /requirements (#393)

Bumps [django](https://github.com/django/django) from 6.0.1 to 6.0.2.
- [Commits](https://github.com/django/django/compare/6.0.1...6.0.2)

---
updated-dependencies:
- dependency-name: django dependency-version: 6.0.2 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump djangorestframework-stubs[compatible-mypy] in /requirements (#395)

Bumps [djangorestframework-stubs[compatible-mypy]](https://github.com/sponsors/typeddjango) from 3.16.7 to 3.16.8.
- [Commits](https://github.com/sponsors/typeddjango/commits)

---
updated-dependencies:
- dependency-name: djangorestframework-stubs[compatible-mypy] dependency-version: 3.16.8 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump django-stubs[compatible-mypy] from 5.2.8 to 5.2.9 in /requirements (#385)

Bumps [django-stubs[compatible-mypy]](https://github.com/sponsors/typeddjango) from 5.2.8 to 5.2.9.
- [Commits](https://github.com/sponsors/typeddjango/commits)

---
updated-dependencies:
- dependency-name: django-stubs[compatible-mypy] dependency-version: 5.2.9 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump python in /compose/production/django (#396)

Bumps python from 3.13.11-slim-bookworm to 3.13.12-slim-bookworm.

---
updated-dependencies:
- dependency-name: python dependency-version: 3.13.12-slim-bookworm dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump coverage from 7.13.2 to 7.13.4 in /requirements (#397)

Bumps [coverage](https://github.com/coveragepy/coveragepy) from 7.13.2 to 7.13.4.
- [Release notes](https://github.com/coveragepy/coveragepy/releases)
- [Changelog](https://github.com/coveragepy/coveragepy/blob/main/CHANGES.rst)
- [Commits](https://github.com/coveragepy/coveragepy/compare/7.13.2...7.13.4)

---
updated-dependencies:
- dependency-name: coverage dependency-version: 7.13.4 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump docker/build-push-action from 6.18.0 to 6.19.1 (#399)

Bumps [docker/build-push-action](https://github.com/docker/build-push-action) from 6.18.0 to 6.19.1.
- [Release notes](https://github.com/docker/build-push-action/releases)
- [Commits](https://github.com/docker/build-push-action/compare/v6.18.0...v6.19.1)

---
updated-dependencies:
- dependency-name: docker/build-push-action dependency-version: 6.19.1 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump docker/build-push-action from 6.19.1 to 6.19.2 (#400)

Bumps [docker/build-push-action](https://github.com/docker/build-push-action) from 6.19.1 to 6.19.2.
- [Release notes](https://github.com/docker/build-push-action/releases)
- [Commits](https://github.com/docker/build-push-action/compare/v6.19.1...v6.19.2)

---
updated-dependencies:
- dependency-name: docker/build-push-action dependency-version: 6.19.2 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump dj-rest-auth[with_social] from 7.0.2 to 7.1.0 in /requirements (#401)

Bumps [dj-rest-auth[with_social]](https://github.com/iMerica/dj-rest-auth) from 7.0.2 to 7.1.0.
- [Release notes](https://github.com/iMerica/dj-rest-auth/releases)
- [Commits](https://github.com/iMerica/dj-rest-auth/compare/7.0.2...7.1.0)

---
updated-dependencies:
- dependency-name: dj-rest-auth[with_social] dependency-version: 7.1.0 dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump pytest-django from 4.11.1 to 4.12.0 in /requirements (#403)

Bumps [pytest-django](https://github.com/pytest-dev/pytest-django) from 4.11.1 to 4.12.0.
- [Release notes](https://github.com/pytest-dev/pytest-django/releases)
- [Changelog](https://github.com/pytest-dev/pytest-django/blob/main/docs/changelog.rst)
- [Commits](https://github.com/pytest-dev/pytest-django/compare/v4.11.1...v4.12.0)

---
upd…